### PR TITLE
Add unit test for CalculateDistance

### DIFF
--- a/TSP_Csharp_WPF.Tests/GlobalUsings.cs
+++ b/TSP_Csharp_WPF.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/TSP_Csharp_WPF.Tests/TSP_Csharp_WPF.Tests.csproj
+++ b/TSP_Csharp_WPF.Tests/TSP_Csharp_WPF.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <ProjectReference Include="..\TSP_Csharp_WPF\TSP_Csharp_WPF.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TSP_Csharp_WPF.Tests/UnitTest1.cs
+++ b/TSP_Csharp_WPF.Tests/UnitTest1.cs
@@ -1,0 +1,16 @@
+namespace TSP_Csharp_WPF.Tests;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void CalculateDistance_ReturnsCorrectValue()
+    {
+        var cityA = new City(0, 0);
+        var cityB = new City(3, 4);
+
+        int distance = FileReader.CalculateDistance(cityA, cityB);
+
+        Assert.AreEqual(5, distance);
+    }
+}

--- a/TSP_Csharp_WPF.sln
+++ b/TSP_Csharp_WPF.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.572
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TSP_Csharp_WPF", "TSP_Csharp_WPF\TSP_Csharp_WPF.csproj", "{703D0F85-4BDD-4430-A1F1-CECB22E36A6B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TSP_Csharp_WPF.Tests", "TSP_Csharp_WPF.Tests\TSP_Csharp_WPF.Tests.csproj", "{3EC62B17-C478-4FE6-9588-8D471BDB122B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{703D0F85-4BDD-4430-A1F1-CECB22E36A6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{703D0F85-4BDD-4430-A1F1-CECB22E36A6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{703D0F85-4BDD-4430-A1F1-CECB22E36A6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{703D0F85-4BDD-4430-A1F1-CECB22E36A6B}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {703D0F85-4BDD-4430-A1F1-CECB22E36A6B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3EC62B17-C478-4FE6-9588-8D471BDB122B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3EC62B17-C478-4FE6-9588-8D471BDB122B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3EC62B17-C478-4FE6-9588-8D471BDB122B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3EC62B17-C478-4FE6-9588-8D471BDB122B}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/TSP_Csharp_WPF/TSP_Csharp_WPF.csproj
+++ b/TSP_Csharp_WPF/TSP_Csharp_WPF.csproj
@@ -104,5 +104,8 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net452" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
## Summary
- add MSTest project `TSP_Csharp_WPF.Tests`
- reference the main `TSP_Csharp_WPF` project
- include package to build Framework references on non-Windows
- verify distance calculation between two cities
- update solution file with the test project

## Testing
- `dotnet test TSP_Csharp_WPF.Tests/TSP_Csharp_WPF.Tests.csproj` *(fails: GenerateResource task could not start)*

------
https://chatgpt.com/codex/tasks/task_e_683f409f790883339a68c907c9bcd771