### PR TITLE
Improve UI responsiveness and optimize distance calc

### DIFF
--- a/TSP_Csharp_WPF/FileReader.cs
+++ b/TSP_Csharp_WPF/FileReader.cs
@@ -26,8 +26,10 @@ namespace TSP_Csharp_WPF
 
         public static int CalculateDistance(City cityA, City cityB) //calculates distances beetwen cities to create distance matrix
         {
-            double Distance = Math.Pow((cityA.X - cityB.X), 2) + Math.Pow((cityA.Y - cityB.Y), 2); //takes coordinations of 2 points (2D - X,Y)
-            return (int)Math.Round(Math.Sqrt(Distance));
+            int dx = cityA.X - cityB.X;
+            int dy = cityA.Y - cityB.Y;
+            double distanceSquared = dx * dx + dy * dy; //takes coordinations of 2 points (2D - X,Y)
+            return (int)Math.Round(Math.Sqrt(distanceSquared));
         }
 
         public static List<City> ReadFile(string filePath) //read file

--- a/TSP_Csharp_WPF/MainWindow.xaml
+++ b/TSP_Csharp_WPF/MainWindow.xaml
@@ -7,12 +7,14 @@
         mc:Ignorable="d"
         Title="WPF TSP SOLVER" Height="829" Width="1000">
     <Grid>
+        <Canvas x:Name="CityCanvas" HorizontalAlignment="Left" Height="800" Margin="194,0,0,0" VerticalAlignment="Top" Width="800" Background="#00FFFFFF" IsHitTestVisible="False"/>
         <Canvas x:Name="Map" HorizontalAlignment="Left" Height="800" Margin="194,0,0,0" VerticalAlignment="Top" Width="800" Background="#FFABABAB"/>
         <Rectangle Fill="#FF710000" HorizontalAlignment="Left" Height="802" Margin="188,0,0,-1.429" Stroke="#FF710000" VerticalAlignment="Top" Width="6"/>
 
         <Button x:Name="StartButton" Content="Start" HorizontalAlignment="Left" Margin="19,371,0,0" VerticalAlignment="Top" Click="StartButton_Click" Height="30" Width="150" FontSize="16" FontWeight="Bold"/>
         <Button x:Name="DataFileButton" Content="Choose Data File" HorizontalAlignment="Left" Margin="19,20,0,0" VerticalAlignment="Top" Width="150" Click="OpenFileButton_Click" Height="30"/>
         <Button x:Name="StopButton" Content="Stop" HorizontalAlignment="Left" Margin="19,419,0,0" VerticalAlignment="Top"  Height="30" Width="150" FontSize="16" FontWeight="Bold" Click="StopButton_Click"/>
+        <ProgressBar x:Name="LoopProgress" HorizontalAlignment="Left" Margin="19,450,0,0" VerticalAlignment="Top" Width="150" Height="20"/>
         
         <Slider x:Name="SliderIndividuals" IsSnapToTickEnabled="True" HorizontalAlignment="Left" Margin="7,138,0,0" VerticalAlignment="Top" Width="147" Maximum="400" SmallChange="10" TickPlacement="BottomRight" Value="100" LargeChange="40" TickFrequency="10" Minimum="10"/>
         <TextBlock HorizontalAlignment="Left" Margin="10,116,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="170"><Run FontSize="10" Text="Individuals in Generation"/><Run FontSize="10" Text=" (10 - 400)"/></TextBlock>

--- a/TSP_Csharp_WPF/MainWindow.xaml.cs
+++ b/TSP_Csharp_WPF/MainWindow.xaml.cs
@@ -26,12 +26,14 @@ namespace TSP_Csharp_WPF
                 Distances.distancesArray = FileReader.CreateDistanceMatrix(CityList); //Create Distances Matrix between cities (Faster calculations during main loop)
 
                 int mapScale = CalculateMapScale(CityList); //adjust map scale to proper show cities on GUI
-                DrawCities(CityList, mapScale); //Draw cities on map
+                DrawCities(CityList, mapScale); //Draw cities on map once
 
                 int individualsInGeneration = (int)SliderIndividuals.Value;
                 int mutationChance = (int)SliderMutation.Value;
                 int crossoverChance = (int)SliderCrossover.Value;
                 int numberOfLoops = 100000; //number of generations
+                LoopProgress.Maximum = numberOfLoops;
+                LoopProgress.Value = 0;
                 int numberOfCities = CityList.Count;
                 Population population = new Population(individualsInGeneration, numberOfCities); //first random population
 
@@ -54,6 +56,7 @@ namespace TSP_Csharp_WPF
                         {
                             DrawLines(population.bestPathInPopulation, CityList, mapScale);
                         }
+                        UpdateProgress(i);
                         UpdateScore(population.lengthofBestPath);
                         UpdateLoopCount(i); //Best score and loop counter is refreshed in every loop repeatation
                     }
@@ -102,6 +105,14 @@ namespace TSP_Csharp_WPF
             });
         }
 
+        void UpdateProgress(int i)
+        {
+            this.Dispatcher.Invoke(() =>
+            {
+                LoopProgress.Value = i;
+            });
+        }
+
         void DataFileDialogWindow()
         {
             Microsoft.Win32.OpenFileDialog openFileDlg = new Microsoft.Win32.OpenFileDialog();
@@ -115,8 +126,9 @@ namespace TSP_Csharp_WPF
             }
         }
 
-        void DrawCities(List<City> cities, int scale) //draw cities on canvas 
+        void DrawCities(List<City> cities, int scale) //draw cities on canvas
         {
+            CityCanvas.Children.Clear();
             foreach (City city in cities) //every city on list of cities (XY coords)
             {
                 this.Dispatcher.Invoke(() =>
@@ -130,7 +142,7 @@ namespace TSP_Csharp_WPF
                     };
                     Canvas.SetLeft(square, city.X / scale);
                     Canvas.SetTop(square, city.Y / scale);
-                    Map.Children.Add(square); //add city to canvas in GUI
+                    CityCanvas.Children.Add(square); //add city to canvas in GUI
                 });
             }
         }
@@ -139,8 +151,7 @@ namespace TSP_Csharp_WPF
         {
             this.Dispatcher.Invoke(() =>
             {
-                Map.Children.Clear(); //clear map to delete old routes
-                DrawCities(cities, scale); //draw cities (it could be optimize to not draw cities every time - but works fine so its not necessary)
+                Map.Children.Clear(); // clear previous route lines
                 for (int i = 0; i < cities.Count - 1; i++) //for every city in path
                 {
                     Line lin = new Line();


### PR DESCRIPTION
## Summary
- add dedicated CityCanvas layer
- add progress bar for generation progress
- avoid redrawing city points each update
- optimize distance calculation

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f4374265483339e32524e0479e0ff